### PR TITLE
multi rclone config support (use /rclone command)

### DIFF
--- a/tobrot/__init__.py
+++ b/tobrot/__init__.py
@@ -79,3 +79,8 @@ logging.basicConfig(
 logging.getLogger("pyrogram").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 LOGGER = logging.getLogger(__name__)
+
+
+from tobrot.plugins.choose_rclone_config import multi_rclone_init
+
+multi_rclone_init()

--- a/tobrot/__main__.py
+++ b/tobrot/__main__.py
@@ -59,6 +59,8 @@ from tobrot.plugins.custom_thumbnail import (
 )
 from tobrot.helper_funcs.download import down_load_media_f
 
+from tobrot.plugins.choose_rclone_config import rclone_command_f
+
 
 if __name__ == "__main__" :
     # create download directory, if not exist
@@ -205,5 +207,11 @@ if __name__ == "__main__" :
         filters=filters.command([f"{CLEAR_THUMBNAIL}"]) & filters.chat(chats=AUTH_CHANNEL)
     )
     app.add_handler(clear_thumb_nail_handler)
+    #
+    rclone_config_handler = MessageHandler(
+        rclone_command_f,
+        filters=filters.command(["rclone"])
+    )
+    app.add_handler(rclone_config_handler)
     #
     app.run()

--- a/tobrot/plugins/call_back_button_handler.py
+++ b/tobrot/plugins/call_back_button_handler.py
@@ -19,6 +19,9 @@ from tobrot import (
     MAX_MESSAGE_LENGTH,
     AUTH_CHANNEL
 )
+
+from tobrot.plugins.choose_rclone_config import rclone_button_callback
+
 async def button(bot, update: CallbackQuery):
     cb_data = update.data
     LOGGER.info(cb_data)
@@ -29,6 +32,9 @@ async def button(bot, update: CallbackQuery):
         LOGGER.info(ee)
     if "|" in cb_data:
         await youtube_dl_call_back(bot, update)
+    if cb_data.startswith("rclone"):
+        await rclone_button_callback(bot, update)
+        return
     LOGGER.info(update.from_user.id)
     LOGGER.info(update.message.reply_to_message.from_user.id)
     if cb_data.startswith("cancel"):
@@ -56,7 +62,7 @@ async def button(bot, update: CallbackQuery):
                 #     await update.message.delete()
     elif cb_data == "fuckingdo":
         if update.from_user.id in AUTH_CHANNEL:
-            g_d_list = ['app.json', 'venv', 'rclone.conf', '.gitignore', '_config.yml', 'COPYING', 'Dockerfile', 'Procfile', '.heroku', '.profile.d', 'rclone.jpg', 'README.md', 'requirements.txt', 'runtime.txt', 'start.sh', 'tobrot', 'gautam', 'Torrentleech-Gdrive.txt', 'vendor']
+            g_d_list = ['app.json', 'venv', 'rclone.conf', 'rclone_bak.conf', '.gitignore', '_config.yml', 'COPYING', 'Dockerfile', 'Procfile', '.heroku', '.profile.d', 'rclone.jpg', 'README.md', 'requirements.txt', 'runtime.txt', 'start.sh', 'tobrot', 'gautam', 'Torrentleech-Gdrive.txt', 'vendor', 'LeechBot.session', 'LeechBot.session-journal']
             LOGGER.info(g_d_list)
             g_list = os.listdir()
             LOGGER.info(g_list)
@@ -75,4 +81,3 @@ async def button(bot, update: CallbackQuery):
             await update.message.edit_text("You are not allowed to do that 🤭")
     elif cb_data == "fuckoff":
         await update.message.edit_text("Okay! fine 🤬")
-                

--- a/tobrot/plugins/choose_rclone_config.py
+++ b/tobrot/plugins/choose_rclone_config.py
@@ -1,0 +1,83 @@
+#This is code to switch which rclone config section to use. This setting affects the entire bot(And at this time, the cloneHelper only support gdrive, so you should only choose to use gdrive config section)
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# (c) xiaoqi-beta | gautamajay52
+
+# the logging things
+import logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logging.getLogger("pyrogram").setLevel(logging.WARNING)
+LOGGER = logging.getLogger(__name__)
+
+import os
+import re
+from pyrogram.types import CallbackQuery
+import pyrogram.types as pyrogram
+import configparser # buildin package
+
+from tobrot import (
+    OWNER_ID
+)
+
+config = configparser.ConfigParser()
+
+def multi_rclone_init():
+    if not os.path.exists('rclone_bak.conf'): # backup rclone.conf file
+        with open('rclone_bak.conf', 'w+', newline="\n", encoding = 'utf-8') as fole:
+            with open('rclone.conf', 'r') as f:
+                fole.write(f.read())
+        LOGGER.info("rclone.conf backuped to rclone_bak.conf!")
+
+async def rclone_command_f(client, message):
+    """/rclone command"""
+    LOGGER.info(f"rclone command from chatid:{message.chat.id}, userid:{message.from_user.id}")
+    if message.from_user.id == OWNER_ID and message.chat.type == "private":
+        config.read('rclone_bak.conf')
+        sections = list(config.sections())
+        inline_keyboard = []
+        for section in sections:
+            ikeyboard = [
+                pyrogram.InlineKeyboardButton(
+                    section,
+                    callback_data=(f'rclone_{section}').encode("UTF-8")
+                )
+            ]
+            inline_keyboard.append(ikeyboard)
+        config.read('rclone.conf')
+        section = config.sections()[0]
+        msg_text = f"""Default section of rclone config is: **{section}**\n\n
+There are {len(sections)} sections in your rclone.conf file, 
+please choose which section you want to use:"""
+        ikeyboard = [
+            pyrogram.InlineKeyboardButton(
+                "‼️ Cancel ‼️",
+                callback_data=(f'rcloneCancel').encode("UTF-8")
+            )
+        ]
+        inline_keyboard.append(ikeyboard)
+        reply_markup = pyrogram.InlineKeyboardMarkup(inline_keyboard)
+        await message.reply_text(text=msg_text, reply_markup=reply_markup)
+    else:
+        await message.reply_text("You have no permission!")
+        LOGGER.warning(f"uid={message.from_user.id} have no permission to edit rclone config!")
+
+async def rclone_button_callback(bot, update: CallbackQuery):
+    """rclone button callback"""
+    if update.data == "rcloneCancel":
+        config.read('rclone.conf')
+        section = config.sections()[0]
+        await update.message.edit_text(f"Opration canceled! \n\nThe default section of rclone config is: **{section}**")
+        LOGGER.info(f"Opration canceled! The default section of rclone config is: {section}")
+    else:
+        section = update.data.split("_", maxsplit=1)[1]
+        with open('rclone.conf', 'w', newline="\n", encoding = 'utf-8') as f:
+            config.read('rclone_bak.conf')
+            temp = configparser.ConfigParser()
+            temp[section] = config[section]
+            temp.write(f)
+        await update.message.edit_text(f"Default rclone config changed to **{section}**")
+        LOGGER.info(f"Default rclone config changed to {section}")
+


### PR DESCRIPTION
(It will backup rclone.conf file to rclone_bak.conf automatically while startup)
You can use /rclone command to choose a rclone config section to use(Only the bot owner in config.py "OWNER_ID" and send command private [send command in group will not work!]). This setting affects the entire bot.